### PR TITLE
autossh not re-opening tunnels when network connectivity dies

### DIFF
--- a/templates/autossh.service.j2
+++ b/templates/autossh.service.j2
@@ -4,7 +4,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart={{ autossh_path }} -M 0 -N -q -o "ServerAliveInterval 60" -o "ServerAliveCountMax 3" \
+ExecStart={{ autossh_path }} -M 0 -N -q -o "ServerAliveInterval 60" -o "ServerAliveCountMax 3" -o "ExitOnForwardFailure=yes" \
 {{ item.forward_mode }} {{ item.bind_address | default(autossh_default_bind_address) }}:{{ item.local_port }}:{{ item.dest_server | default(autossh_default_dest_server) }}:{{ item.dest_port }} \
 -i {{ item.identity_file | default(autossh_default_identity_file) }} \
 {{ item.user }}@{{ item.server }}

--- a/templates/autossh.sysvinit.j2
+++ b/templates/autossh.sysvinit.j2
@@ -22,7 +22,7 @@ start() {
         echo -n $"Starting $prog: "
         export AUTOSSH_PIDFILE="$PIDFILE"
 	daemon --pidfile="$PIDFILE" {{ autossh_path }} \
-             -f -M 0 -N -v -o "\"ServerAliveInterval 60\"" -o "\"ServerAliveCountMax 3\"" \
+             -f -M 0 -N -v -o "\"ServerAliveInterval 60\"" -o "\"ServerAliveCountMax 3\"" -o "\"ExitOnForwardFailure=yes\"" \
              {{ item.forward_mode }} {{ item.bind_address | default(autossh_default_bind_address) }}:{{ item.local_port }}:{{ item.dest_server | default(autossh_default_dest_server) }}:{{ item.dest_port }} \
              -i {{ item.identity_file | default(autossh_default_identity_file) }} \
              {{ item.user }}@{{ item.server }}


### PR DESCRIPTION
Adding "-o ExitOnOnForwardFailure=yes" to overcome when connectivity breaks, so that autossh kills and respawns the tunnel.